### PR TITLE
Call the unload handler after each startup test

### DIFF
--- a/build/lib/adapterTools.d.ts
+++ b/build/lib/adapterTools.d.ts
@@ -30,6 +30,11 @@ export declare function locateAdapterMainFile(adapterDir: string): Promise<strin
  */
 export declare function loadAdapterConfig(adapterDir: string): Record<string, any>;
 /**
+ * Loads the adapter's common configuration from `io-package.json`
+ * @param adapterDir The directory the adapter resides in
+ */
+export declare function loadAdapterCommon(adapterDir: string): Record<string, any>;
+/**
  * Loads the instanceObjects for an adapter from its `io-package.json`
  * @param adapterDir The directory the adapter resides in
  */

--- a/build/lib/adapterTools.js
+++ b/build/lib/adapterTools.js
@@ -86,6 +86,15 @@ function loadAdapterConfig(adapterDir) {
 }
 exports.loadAdapterConfig = loadAdapterConfig;
 /**
+ * Loads the adapter's common configuration from `io-package.json`
+ * @param adapterDir The directory the adapter resides in
+ */
+function loadAdapterCommon(adapterDir) {
+    const ioPackage = loadIoPackage(adapterDir);
+    return ioPackage.common || {};
+}
+exports.loadAdapterCommon = loadAdapterCommon;
+/**
  * Loads the instanceObjects for an adapter from its `io-package.json`
  * @param adapterDir The directory the adapter resides in
  */

--- a/build/tests/unit/harness/startMockAdapter.d.ts
+++ b/build/tests/unit/harness/startMockAdapter.d.ts
@@ -30,3 +30,4 @@ export declare function startMockAdapter(adapterMainFile: string, options?: Star
     processExitCode: number | undefined;
     terminateReason: string | undefined;
 }>;
+export declare function unloadMockAdapter(adapter: MockAdapter, timeout?: number): Promise<boolean>;

--- a/build/tests/unit/harness/startMockAdapter.js
+++ b/build/tests/unit/harness/startMockAdapter.js
@@ -123,3 +123,30 @@ function startMockAdapter(adapterMainFile, options = {}) {
     });
 }
 exports.startMockAdapter = startMockAdapter;
+function unloadMockAdapter(adapter, timeout = 500) {
+    chai_1.expect(adapter.unloadHandler, "The adapter's unload method could not be found!").to.exist;
+    return new Promise((res, rej) => {
+        function finishUnload() {
+            res(true);
+        }
+        if (adapter.unloadHandler.length >= 1) {
+            // The method takes (at least) a callback
+            adapter.unloadHandler(finishUnload);
+        }
+        else {
+            // The method takes no arguments, so it must return a Promise
+            const unloadPromise = adapter.unloadHandler();
+            if (unloadPromise instanceof Promise) {
+                // Call finishUnload in the case of success and failure
+                unloadPromise.then(finishUnload, finishUnload);
+            }
+            else {
+                // No callback accepted and no Promise returned - force unload
+                rej(new Error(`The unload method must return a Promise if it does not accept a callback!`));
+            }
+        }
+        // If the developer forgets to call the callback within the configured time, fail the test
+        setTimeout(() => rej(new Error("The unload callback was not called within the timeout")), timeout);
+    });
+}
+exports.unloadMockAdapter = unloadMockAdapter;

--- a/build/tests/unit/index.js
+++ b/build/tests/unit/index.js
@@ -30,6 +30,7 @@ function testAdapterWithMocks(adapterDir, options = {}) {
         // Ensure that a valid exit code was returned. By default, only 0 is allowed
         chai_1.expect(allowedExitCodes).contains(exitCode, `process.exit was called with the unexpected exit code ${exitCode}!`);
     }
+    const adapterCommon = adapterTools_1.loadAdapterCommon(adapterDir);
     const adapterConfig = adapterTools_1.loadAdapterConfig(adapterDir);
     const instanceObjects = adapterTools_1.loadInstanceObjects(adapterDir);
     const supportsCompactMode = adapterTools_1.adapterShouldSupportCompactMode(adapterDir);
@@ -51,7 +52,9 @@ function testAdapterWithMocks(adapterDir, options = {}) {
                     adapterDir,
                 });
                 assertValidExitCode(options.allowedExitCodes || [], processExitCode);
-                // TODO: Test that the unload callback is called
+                // Test that the unload callback is called
+                const unloadTestResult = yield startMockAdapter_1.unloadMockAdapter(adapterMock, adapterCommon.stopTimeout);
+                chai_1.expect(unloadTestResult).to.be.true;
             });
         });
         if (supportsCompactMode) {
@@ -70,7 +73,11 @@ function testAdapterWithMocks(adapterDir, options = {}) {
                     });
                     // In compact mode, only "adapter.terminate" may be called
                     chai_1.expect(processExitCode, "In compact mode, process.exit() must not be called!").to.be.undefined;
-                    // TODO: Test that the unload callback is called (if terminateReason is undefined)
+                    // Test that the unload callback is called
+                    if (terminateReason != undefined) {
+                        const unloadTestResult = yield startMockAdapter_1.unloadMockAdapter(adapterMock, adapterCommon.stopTimeout);
+                        chai_1.expect(unloadTestResult).to.be.true;
+                    }
                 });
             });
         }

--- a/src/lib/adapterTools.ts
+++ b/src/lib/adapterTools.ts
@@ -79,6 +79,15 @@ export function loadAdapterConfig(adapterDir: string): Record<string, any> {
 }
 
 /**
+ * Loads the adapter's common configuration from `io-package.json`
+ * @param adapterDir The directory the adapter resides in
+ */
+export function loadAdapterCommon(adapterDir: string): Record<string, any> {
+	const ioPackage = loadIoPackage(adapterDir);
+	return ioPackage.common || {};
+}
+
+/**
  * Loads the instanceObjects for an adapter from its `io-package.json`
  * @param adapterDir The directory the adapter resides in
  */

--- a/src/tests/unit/harness/startMockAdapter.ts
+++ b/src/tests/unit/harness/startMockAdapter.ts
@@ -54,7 +54,7 @@ export async function startMockAdapter(adapterMainFile: string, options: StartMo
 	});
 
 	// Replace the following modules with mocks
-	const mockedModules: Record<string, any> = { };
+	const mockedModules: Record<string, any> = {};
 	if (options.additionalMockedModules) {
 		for (let [mdl, mock] of entries(options.additionalMockedModules)) {
 			mdl = mdl.replace("{CONTROLLER_DIR}", adapterCoreMock.controllerDir);
@@ -119,4 +119,30 @@ export async function startMockAdapter(adapterMainFile: string, options: StartMo
 		processExitCode,
 		terminateReason,
 	};
+}
+
+export function unloadMockAdapter(adapter: MockAdapter, timeout: number = 500) {
+	expect(adapter.unloadHandler, "The adapter's unload method could not be found!").to.exist;
+	return new Promise<boolean>((res, rej) => {
+		function finishUnload() {
+			res(true);
+		}
+		if (adapter.unloadHandler!.length >= 1) {
+			// The method takes (at least) a callback
+			adapter.unloadHandler!(finishUnload);
+		} else {
+			// The method takes no arguments, so it must return a Promise
+			const unloadPromise = (adapter.unloadHandler as any)();
+			if (unloadPromise instanceof Promise) {
+				// Call finishUnload in the case of success and failure
+				unloadPromise.then(finishUnload, finishUnload);
+			} else {
+				// No callback accepted and no Promise returned - force unload
+				rej(new Error(`The unload method must return a Promise if it does not accept a callback!`));
+			}
+		}
+
+		// If the developer forgets to call the callback within the configured time, fail the test
+		setTimeout(() => rej(new Error("The unload callback was not called within the timeout")), timeout);
+	});
 }


### PR DESCRIPTION
and assert that the callback was called.

Fixes: #15 