### PR TITLE
Revert "Bump @types/chai from 4.1.7 to 4.2.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -152,9 +152,9 @@
       "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ=="
     },
     "@types/chai": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.0.tgz",
-      "integrity": "sha512-zw8UvoBEImn392tLjxoavuonblX/4Yb9ha4KBU10FirCfwgzhKO0dvyJSF9ByxV1xK1r2AgnAi/tvQaLgxQqxA==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.1.7.tgz",
+      "integrity": "sha512-2Y8uPt0/jwjhQ6EiluT0XCri1Dbplr0ZxfFXUz+ye13gaqE8u5gL5ppao1JrUYr9cIip5S6MvQzBS7Kke7U9VA==",
       "dev": true
     },
     "@types/chai-as-promised": {


### PR DESCRIPTION
Reverts ioBroker/testing#112 as this might be responsible for all further build breaks with sinon-chai and similar packages.