### PR TITLE
Bugfix: Set the object ID when extending it

### DIFF
--- a/build/tests/unit/mocks/mockAdapter.js
+++ b/build/tests/unit/mocks/mockAdapter.js
@@ -188,6 +188,7 @@ function createAdapterMock(db, options = {}) {
                 id = ret.namespace + "." + id;
             const existing = db.getObject(id) || {};
             const target = objects_1.extend({}, existing, obj);
+            target._id = id;
             db.publishObject(target);
             const callback = getCallback(...args);
             if (callback)
@@ -234,6 +235,7 @@ function createAdapterMock(db, options = {}) {
         extendForeignObject: ((id, obj, ...args) => {
             const target = db.getObject(id) || {};
             Object.assign(target, obj);
+            target._id = id;
             db.publishObject(target);
             const callback = getCallback(...args);
             if (callback)

--- a/src/tests/unit/mocks/mockAdapter.ts
+++ b/src/tests/unit/mocks/mockAdapter.ts
@@ -248,6 +248,7 @@ export function createAdapterMock(
 			if (!id.startsWith(ret.namespace)) id = ret.namespace + "." + id;
 			const existing = db.getObject(id) || {};
 			const target = extend({}, existing, obj) as ioBroker.Object;
+			target._id = id;
 			db.publishObject(target);
 			const callback = getCallback<ioBroker.ExtendObjectCallback>(
 				...args,
@@ -302,6 +303,7 @@ export function createAdapterMock(
 		) => {
 			const target = db.getObject(id) || ({} as ioBroker.Object);
 			Object.assign(target, obj);
+			target._id = id;
 			db.publishObject(target);
 			const callback = getCallback<ioBroker.ExtendObjectCallback>(
 				...args,


### PR DESCRIPTION
The following code currently throws an error if the object doesn't exist yet:
```js
await this.extendObjectAsync(sectionName, {
    type: 'channel',
    common: {
        name: sectionName,
    },
});
```
```text
Error: An object must have an ID
 at MockDatabase.publishObject (node_modules/@iobroker/testing/build/tests/unit/mocks/mockDatabase.js:36:19)
 at Luxtronik2.extendObject (node_modules/@iobroker/testing/build/tests/unit/mocks/mockAdapter.js:192:16)
 ...
```
But this is very much allowed in js-controller. It will take the first argument to the function as its id when creating it.