### PR TITLE
fix: locate adapter main file when only defined in package.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 	## __WORK IN PROGRESS__
 -->
 
+## __WORK IN PROGRESS__
+* Fix: The adapter main file now correctly gets located when it is only defined in `package.json`, not `io-package.json`
+
 ## 2.4.2 (2021-01-06)
 * Fixed compatibility with the reworked database classes
 * Improved shutdown behavior of the adapter

--- a/build/lib/adapterTools.js
+++ b/build/lib/adapterTools.js
@@ -68,10 +68,13 @@ function locateAdapterMainFile(adapterDir) {
     return __awaiter(this, void 0, void 0, function* () {
         debug(`locating adapter main file in ${adapterDir}...`);
         const ioPackage = loadIoPackage(adapterDir);
-        // First look for the file defined in io-package.json or use "main.js" as a fallback
+        const npmPackage = loadNpmPackage(adapterDir);
+        // First look for the file defined in io-package.json or package.json or use "main.js" as a fallback
         const mainFile = typeof ioPackage.common.main === "string"
             ? ioPackage.common.main
-            : "main.js";
+            : typeof npmPackage.main === "string"
+                ? npmPackage.main
+                : "main.js";
         let ret = path.join(adapterDir, mainFile);
         debug(`  => trying ${ret}`);
         if (yield fs_extra_1.pathExists(ret)) {

--- a/src/lib/adapterTools.ts
+++ b/src/lib/adapterTools.ts
@@ -50,11 +50,14 @@ export async function locateAdapterMainFile(
 ): Promise<string> {
 	debug(`locating adapter main file in ${adapterDir}...`);
 	const ioPackage = loadIoPackage(adapterDir);
+	const npmPackage = loadNpmPackage(adapterDir);
 
-	// First look for the file defined in io-package.json or use "main.js" as a fallback
+	// First look for the file defined in io-package.json or package.json or use "main.js" as a fallback
 	const mainFile =
 		typeof ioPackage.common.main === "string"
 			? ioPackage.common.main
+			: typeof npmPackage.main === "string"
+			? npmPackage.main
 			: "main.js";
 
 	let ret = path.join(adapterDir, mainFile);


### PR DESCRIPTION
fixes: #393 