### PR TITLE
fix: ensure db type is "file"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 	PLACEHOLDER for next version:
 	## __WORK IN PROGRESS__
 -->
+## __WORK IN PROGRESS__
+* Fix: Ensure the tests use the `file` DB type
+
 ## 2.5.2 (2021-09-18)
 * Fix: `adminUI.config` is now respected for the config UI check and JSON config is allowed too
 * Updated dependencies

--- a/build/tests/integration/lib/controllerSetup.js
+++ b/build/tests/integration/lib/controllerSetup.js
@@ -176,11 +176,13 @@ class ControllerSetup {
      * @param testDir The directory the integration tests are executed in
      */
     async setupSystemConfig() {
-        debug("Moving databases to different ports...");
+        debug(`Moving databases to different ports and setting type "file"...`);
         const systemFilename = path.join(this.testDataDir, `${this.appName}.json`);
         const systemConfig = require(systemFilename);
         systemConfig.objects.port = 19001;
+        systemConfig.objects.type = "file";
         systemConfig.states.port = 19000;
+        systemConfig.states.type = "file";
         await (0, fs_extra_1.writeFile)(systemFilename, JSON.stringify(systemConfig, null, 2));
         debug("  => done!");
     }

--- a/src/tests/integration/lib/controllerSetup.ts
+++ b/src/tests/integration/lib/controllerSetup.ts
@@ -202,7 +202,7 @@ export class ControllerSetup {
 	 * @param testDir The directory the integration tests are executed in
 	 */
 	public async setupSystemConfig(): Promise<void> {
-		debug("Moving databases to different ports...");
+		debug(`Moving databases to different ports and setting type "file"...`);
 
 		const systemFilename = path.join(
 			this.testDataDir,
@@ -210,7 +210,9 @@ export class ControllerSetup {
 		);
 		const systemConfig = require(systemFilename);
 		systemConfig.objects.port = 19001;
+		systemConfig.objects.type = "file";
 		systemConfig.states.port = 19000;
+		systemConfig.states.type = "file";
 		await writeFile(systemFilename, JSON.stringify(systemConfig, null, 2));
 		debug("  => done!");
 	}


### PR DESCRIPTION
This is a solution for the underlying issue of #459, but without changing everything to support jsonl.
We should still be able to support the JSONL-DB, but this is a short-term fix to be able to remove the workaround in controller.