### PR TITLE
add licenseInformation, add tier test and honor onlyWWW

### DIFF
--- a/src/tests/packageFiles/index.ts
+++ b/src/tests/packageFiles/index.ts
@@ -89,6 +89,7 @@ export function validatePackageFiles(adapterDir: string): void {
 			});
 
 			const packageContent = require(packageJsonPath);
+			const iopackContent = require(ioPackageJsonPath);
 
 			const requiredProperties = [
 				"name",
@@ -96,7 +97,6 @@ export function validatePackageFiles(adapterDir: string): void {
 				"description",
 				"author",
 				"license",
-				"main",
 				"repository",
 				"repository.type",
 			];
@@ -124,6 +124,12 @@ export function validatePackageFiles(adapterDir: string): void {
 					/[a-z0-9]$/,
 					`The adapter name must end with a letter or number!`,
 				);
+			});
+
+			it(`property main is defined for non onlyWWW adapters`, () => {
+				if (!iopackContent.common.onlyWWW){
+					expect(packageContent.main).to.not.be.undefined;
+				}
 			});
 
 			it(`The repository type is "git"`, () => {
@@ -164,7 +170,6 @@ export function validatePackageFiles(adapterDir: string): void {
 				"common.desc",
 				"common.icon",
 				"common.extIcon",
-				"common.license",
 				"common.type",
 				"common.authors",
 				"native",
@@ -204,6 +209,32 @@ export function validatePackageFiles(adapterDir: string): void {
 				expect(Object.keys(news).length).to.be.at.most(20);
 			});
 
+			if (iopackContent.common.licenseInformation) {
+				it(`if common.licenseInformation exists, it is an object with required properties`, () => {
+					expect(iopackContent.common.licenseInformation).to.be.an("object");
+					expect(iopackContent.common.licenseInformation.type).to.be.oneOf(['free', 'commercial', 'paid', 'limited']);
+
+					if (iopackContent.common.licenseInformation.type !== "free") {
+						expect(iopackContent.common.licenseInformation.link, 'License link is missing').to.not.be.undefined;
+					}
+				});
+
+				it(`common.license should not exist together with common.licenseInformation`, () => {
+					expect(iopackContent.common.license, 'common.license must be removed').to.be.undefined;
+				});
+			} else {
+				it(`common.license must exist without common.licenseInformation`, () => {
+					expect(iopackContent.common.license, 'common.license or common.licenseInformation must exit').to.not.be.undefined;
+				});	
+			}
+
+			if (iopackContent.common.tier) {
+				it(`common.tier must be 1, 2 or 3`, () => {
+					expect(iopackContent.common.tier).to.be.at.least(1);
+					expect(iopackContent.common.tier).to.be.at.most(3);
+				});
+			}
+			
 			// If the adapter has a configuration page, check that a supported admin UI is used
 			const hasNoConfigPage =
 				iopackContent.common.noConfig === true ||
@@ -245,9 +276,15 @@ export function validatePackageFiles(adapterDir: string): void {
 			});
 
 			it("The license matches", () => {
-				expect(iopackContent.common.license).to.equal(
-					packageContent.license,
-				);
+				if (iopackContent.common.licenseInformation) {
+					expect(iopackContent.common.licenseInformation.license).to.equal(
+						packageContent.license,
+					);
+				} else {
+					expect(iopackContent.common.license).to.equal(
+						packageContent.license,
+					);
+				}
 			});
 		});
 	});


### PR DESCRIPTION
This PR adapts tests as following:

fixes for https://github.com/ioBroker/testing/issues/592
- if common.licenseInformation is present common.license must not exist
- package.license is compared againts eitehr io-package.common.license or iopackage.common.licenseInformation.license
- common.licenseInformation is checked to be an object containing required components

fixes for https://github.com/ioBroker/testing/issues/577
- if common.onlyWWW is set package.json need no longer have a main attribute

Additonal
- common.tier is checked to be between 1 and 3 if present.