### PR TITLE
fix: use shell to spawn `npm` on Windows

### DIFF
--- a/build/lib/executeCommand.js
+++ b/build/lib/executeCommand.js
@@ -30,10 +30,15 @@ function executeCommand(command, argsOrOptions, options) {
             spawnOptions.cwd = options.cwd;
         // Fix npm / node executable paths on Windows
         if (isWindows) {
-            if (command === "npm")
+            if (command === "npm") {
                 command += ".cmd";
-            else if (command === "node")
+                // Needed since Node.js v18.20.2 and v20.12.2
+                // https://github.com/nodejs/node/releases/tag/v18.20.2
+                spawnOptions.shell = true;
+            }
+            else if (command === "node") {
                 command += ".exe";
+            }
         }
         if (options.logCommandExecution == null)
             options.logCommandExecution = false;

--- a/build/tests/integration/lib/dbConnection.d.ts
+++ b/build/tests/integration/lib/dbConnection.d.ts
@@ -3,8 +3,8 @@
 /// <reference types="node" />
 /// <reference types="node" />
 import EventEmitter from "events";
-export declare type ObjectsDB = Record<string, ioBroker.Object>;
-export declare type StatesDB = Record<string, ioBroker.State>;
+export type ObjectsDB = Record<string, ioBroker.Object>;
+export type StatesDB = Record<string, ioBroker.State>;
 export interface DBConnection {
     on(event: "objectChange", handler: ioBroker.ObjectChangeHandler): this;
     on(event: "stateChange", handler: ioBroker.StateChangeHandler): this;

--- a/build/tests/packageFiles/index.js
+++ b/build/tests/packageFiles/index.js
@@ -93,13 +93,13 @@ function validatePackageFiles(adapterDir) {
                 skipIfInvalid.call(this, "package.json");
             });
             const packageContent = require(packageJsonPath);
+            const iopackContent = require(ioPackageJsonPath);
             const requiredProperties = [
                 "name",
                 "version",
                 "description",
                 "author",
                 "license",
-                "main",
                 "repository",
                 "repository.type",
             ];
@@ -112,6 +112,11 @@ function validatePackageFiles(adapterDir) {
                 (0, chai_1.expect)(name).to.match(/^[a-z]/, `The adapter name must start with a letter!`);
                 (0, chai_1.expect)(name).to.match(/[a-z0-9]$/, `The adapter name must end with a letter or number!`);
             });
+            if (!iopackContent.common.onlyWWW) {
+                it(`property main is defined for non onlyWWW adapters`, () => {
+                    (0, chai_1.expect)(packageContent.main).to.not.be.undefined;
+                });
+            }
             it(`The repository type is "git"`, () => {
                 (0, chai_1.expect)(packageContent.repository.type).to.equal("git");
             });
@@ -142,7 +147,6 @@ function validatePackageFiles(adapterDir) {
                 "common.desc",
                 "common.icon",
                 "common.extIcon",
-                "common.license",
                 "common.type",
                 "common.authors",
                 "native",
@@ -174,6 +178,29 @@ function validatePackageFiles(adapterDir) {
                 (0, chai_1.expect)((0, typeguards_1.isObject)(news)).to.be.true;
                 (0, chai_1.expect)(Object.keys(news).length).to.be.at.most(20);
             });
+            if (iopackContent.common.licenseInformation) {
+                it(`if common.licenseInformation exists, it is an object with required properties`, () => {
+                    (0, chai_1.expect)(iopackContent.common.licenseInformation).to.be.an("object");
+                    (0, chai_1.expect)(iopackContent.common.licenseInformation.type).to.be.oneOf(["free", "commercial", "paid", "limited"]);
+                    if (iopackContent.common.licenseInformation.type !== "free") {
+                        (0, chai_1.expect)(iopackContent.common.licenseInformation.link, "License link is missing").to.not.be.undefined;
+                    }
+                });
+                it(`common.license should not exist together with common.licenseInformation`, () => {
+                    (0, chai_1.expect)(iopackContent.common.license, "common.license must be removed").to.be.undefined;
+                });
+            }
+            else {
+                it(`common.license must exist without common.licenseInformation`, () => {
+                    (0, chai_1.expect)(iopackContent.common.license, "common.licenseInformation (preferred) or common.license (deprecated) must exist").to.not.be.undefined;
+                });
+            }
+            if (iopackContent.common.tier != undefined) {
+                it(`common.tier must be 1, 2 or 3`, () => {
+                    (0, chai_1.expect)(iopackContent.common.tier).to.be.at.least(1);
+                    (0, chai_1.expect)(iopackContent.common.tier).to.be.at.most(3);
+                });
+            }
             // If the adapter has a configuration page, check that a supported admin UI is used
             const hasNoConfigPage = iopackContent.common.noConfig === true ||
                 iopackContent.common.noConfig === "true" ||
@@ -200,7 +227,12 @@ function validatePackageFiles(adapterDir) {
                 (0, chai_1.expect)(iopackContent.common.version).to.equal(packageContent.version);
             });
             it("The license matches", () => {
-                (0, chai_1.expect)(iopackContent.common.license).to.equal(packageContent.license);
+                if (iopackContent.common.licenseInformation) {
+                    (0, chai_1.expect)(iopackContent.common.licenseInformation.license).to.equal(packageContent.license);
+                }
+                else {
+                    (0, chai_1.expect)(iopackContent.common.license).to.equal(packageContent.license);
+                }
             });
         });
     });

--- a/build/tests/unit/mocks/mockAdapter.d.ts
+++ b/build/tests/unit/mocks/mockAdapter.d.ts
@@ -2,7 +2,7 @@
 import type { MockDatabase } from "./mockDatabase";
 import { MockLogger } from "./mockLogger";
 import { Mock } from "./tools";
-export declare type MockAdapter = Mock<ioBroker.Adapter> & {
+export type MockAdapter = Mock<ioBroker.Adapter> & {
     readyHandler: ioBroker.ReadyHandler | undefined;
     objectChangeHandler: ioBroker.ObjectChangeHandler | undefined;
     stateChangeHandler: ioBroker.StateChangeHandler | undefined;

--- a/build/tests/unit/mocks/mockLogger.d.ts
+++ b/build/tests/unit/mocks/mockLogger.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="iobroker" />
 import { Mock } from "./tools";
-export declare type MockLogger = Mock<ioBroker.Logger> & {
+export type MockLogger = Mock<ioBroker.Logger> & {
     resetMock(): void;
     resetMockHistory(): void;
     resetMockBehavior(): void;

--- a/build/tests/unit/mocks/tools.d.ts
+++ b/build/tests/unit/mocks/tools.d.ts
@@ -1,13 +1,13 @@
 /// <reference types="sinon" />
 import type { Equals, Overwrite } from "alcalzone-shared/types";
-export declare type IsAny<T> = Equals<T extends never ? false : true, boolean>;
-export declare type MockableMethods<T, All = Required<T>, NoAny = {
+export type IsAny<T> = Equals<T extends never ? false : true, boolean>;
+export type MockableMethods<T, All = Required<T>, NoAny = {
     [K in keyof All]: IsAny<All[K]> extends true ? never : All[K] extends (...args: any[]) => void ? K : never;
 }> = NoAny[keyof NoAny];
-export declare type Mock<T extends {}> = Overwrite<T, {
+export type Mock<T extends {}> = Overwrite<T, {
     [K in MockableMethods<T>]: sinon.SinonStub;
 }>;
 export declare function doResetHistory(parent: Record<string, any>): void;
 export declare function doResetBehavior(parent: Record<string, any>, implementedMethods: Record<string, any>): void;
 export declare function stubAndPromisifyImplementedMethods<T extends string>(parent: Record<T, any>, implementedMethods: Partial<Record<T, any>>, allowUserOverrides?: T[]): void;
-export declare type ImplementedMethodDictionary<T> = Partial<Record<MockableMethods<T>, "none" | "normal" | "no error">>;
+export type ImplementedMethodDictionary<T> = Partial<Record<MockableMethods<T>, "none" | "normal" | "no error">>;

--- a/src/lib/executeCommand.ts
+++ b/src/lib/executeCommand.ts
@@ -73,8 +73,7 @@ export function executeCommand(
 			if (command === "npm") {
 				command += ".cmd";
 				spawnOptions.shell = true;
-			}
-			else if (command === "node") command += ".exe";
+			} else if (command === "node") command += ".exe";
 		}
 
 		if (options.logCommandExecution == null)

--- a/src/lib/executeCommand.ts
+++ b/src/lib/executeCommand.ts
@@ -1,5 +1,5 @@
 import { isArray, isObject } from "alcalzone-shared/typeguards";
-import { spawn, SpawnOptions } from "child_process";
+import { SpawnOptions, spawn } from "child_process";
 
 const isWindows = /^win/.test(process.platform);
 
@@ -72,8 +72,12 @@ export function executeCommand(
 		if (isWindows) {
 			if (command === "npm") {
 				command += ".cmd";
+				// Needed since Node.js v18.20.2 and v20.12.2
+				// https://github.com/nodejs/node/releases/tag/v18.20.2
 				spawnOptions.shell = true;
-			} else if (command === "node") command += ".exe";
+			} else if (command === "node") {
+				command += ".exe";
+			}
 		}
 
 		if (options.logCommandExecution == null)

--- a/src/lib/executeCommand.ts
+++ b/src/lib/executeCommand.ts
@@ -70,7 +70,10 @@ export function executeCommand(
 
 		// Fix npm / node executable paths on Windows
 		if (isWindows) {
-			if (command === "npm") command += ".cmd";
+			if (command === "npm") {
+				command += ".cmd";
+				spawnOptions.shell=true;
+			}
 			else if (command === "node") command += ".exe";
 		}
 

--- a/src/lib/executeCommand.ts
+++ b/src/lib/executeCommand.ts
@@ -72,7 +72,7 @@ export function executeCommand(
 		if (isWindows) {
 			if (command === "npm") {
 				command += ".cmd";
-				spawnOptions.shell=true;
+				spawnOptions.shell = true;
 			}
 			else if (command === "node") command += ".exe";
 		}


### PR DESCRIPTION
Due to a windows "security fix" release around 15.4.2024 spawing a .cmd (or .bat) file requires an additional option shell:true.

Tests on windows stalled (until timeout occured) starting 15.4.2024 when spawing npm subcommand. This PR ass the required shell:true option.

TESTING:
Unchanged version should hang on windows tests, at (Re)Installing js-controller, i.e.
https://github.com/iobroker-community-adapters/ioBroker.haier/actions/runs/8703117264/job/23868610356

After applying the fix tests should not time out any longer

NOTE:
Tests on Linux and Mac are NOT affected