### PR TITLE
Allow (deprecated) HTML as admin UI in package tests

### DIFF
--- a/src/tests/packageFiles/index.ts
+++ b/src/tests/packageFiles/index.ts
@@ -259,6 +259,7 @@ export function validatePackageFiles(adapterDir: string): void {
 				it("The adapter uses Material UI or JSON Config for the admin UI", () => {
 					const hasSupportedUI =
 						!!iopackContent.common.materialize ||
+						iopackContent.common.adminUI?.config === "html" ||
 						iopackContent.common.adminUI?.config === "json" ||
 						iopackContent.common.adminUI?.config === "materialize";
 

--- a/src/tests/packageFiles/index.ts
+++ b/src/tests/packageFiles/index.ts
@@ -256,7 +256,7 @@ export function validatePackageFiles(adapterDir: string): void {
 				iopackContent.common.noConfig === "true" ||
 				iopackContent.common.adminUI?.config === "none";
 			if (!hasNoConfigPage) {
-				it("The adapter uses Material UI or JSON Config for the admin UI", () => {
+				it("The adapter uses a supported admin UI", () => {
 					const hasSupportedUI =
 						!!iopackContent.common.materialize ||
 						iopackContent.common.adminUI?.config === "html" ||

--- a/src/tests/packageFiles/index.ts
+++ b/src/tests/packageFiles/index.ts
@@ -265,7 +265,7 @@ export function validatePackageFiles(adapterDir: string): void {
 
 					expect(
 						hasSupportedUI,
-						"Unsupported Admin UI, must be materialize or json config!",
+						"Unsupported Admin UI, must use a supported admin UI!",
 					).to.be.true;
 				});
 			}

--- a/src/tests/packageFiles/index.ts
+++ b/src/tests/packageFiles/index.ts
@@ -265,7 +265,7 @@ export function validatePackageFiles(adapterDir: string): void {
 
 					expect(
 						hasSupportedUI,
-						"Unsupported Admin UI, must use a supported admin UI!",
+						"Unsupported Admin UI, must be html, materialize or JSON config!",
 					).to.be.true;
 				});
 			}


### PR DESCRIPTION
As the current schema still allows HTML UI and HTML UI still works as expected the adapetr checks should allow it too.
Otherwise those old adapter need to disable the package tests completly which is worse (in my opinion).

Link to io-package.json schema: https://github.com/ioBroker/ioBroker.js-controller/blob/79fe972a23cee7c7fbf65d19aba044827f843d25/schemas/io-package.json#L796