### PR TITLE
Auto-update github actions using Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,13 @@ updates:
   assignees:
   - AlCalzone
   versioning-strategy: increase
+
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: monthly
+    time: "04:00"
+    timezone: Europe/Berlin
+  open-pull-requests-limit: 15
+  assignees:
+  - AlCalzone

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,6 @@ updates:
     interval: monthly
     time: "04:00"
     timezone: Europe/Berlin
-  open-pull-requests-limit: 15
+  open-pull-requests-limit: 5
   assignees:
   - AlCalzone


### PR DESCRIPTION
As this repo uses dependabot anyway I would suggest to use dependabot for github-actions ecosystem too. Without this entry actions within workflows are not checked / suggested for update.

This PR adds github-actions ecosystem to dependabot. Please evaluate and merge or simply close depending on your decision.